### PR TITLE
Add train_fabric.py

### DIFF
--- a/train_fabric.py
+++ b/train_fabric.py
@@ -14,6 +14,8 @@ $ lightning run model --accelerator=cuda --precision=bf16 --devices=8 --num_node
 - Run on the worker node:
 $ lightning run model --accelerator=cuda --precision=bf16 --devices=8 --num_nodes=2 --node_rank=1 --main_address=123.456.123.456 --main_port=1234 train_fabric.py
 (If your cluster does not have Infiniband interconnect prepend NCCL_IB_DISABLE=1)
+
+Try also --strategy="deepspeed" with devices > 1.
 """
 
 import os
@@ -71,7 +73,6 @@ exec(open('configurator.py').read()) # overrides from command line or config fil
 config = {k: globals()[k] for k in config_keys} # will be useful for logging
 # -----------------------------------------------------------------------------
 
-# Try also strategy="ddp" or strategy="deepspeed" with devices > 1
 fabric = Fabric()
 
 master_process = fabric.global_rank == 0

--- a/train_fabric.py
+++ b/train_fabric.py
@@ -72,8 +72,7 @@ config = {k: globals()[k] for k in config_keys} # will be useful for logging
 # -----------------------------------------------------------------------------
 
 # Try also strategy="ddp" or strategy="deepspeed" with devices > 1
-fabric = Fabric(accelerator="cuda", devices=4, strategy="ddp", precision="bf16")
-fabric.launch()
+fabric = Fabric(accelerator="cuda", precision="bf16")
 
 master_process = fabric.global_rank == 0
 

--- a/train_fabric.py
+++ b/train_fabric.py
@@ -3,16 +3,16 @@ This training script can be run both on a single gpu in debug mode,
 and also in a larger training run with distributed data parallel (ddp).
 
 To run on a single GPU, example:
-$ python train.py --batch_size=32 --compile=False
+$ lightning run model --accelerator=cuda --precision=bf16 train_fabric.py
 
 To run with DDP on 4 gpus on 1 node, example:
-$ torchrun --standalone --nproc_per_node=4 train.py
+$ lightning run model --accelerator=cuda --precision=bf16 --devices=4 train_fabric.py
 
 To run with DDP on 4 gpus across 2 nodes, example:
 - Run on the first (master) node with example IP 123.456.123.456:
-$ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=0 --master_addr=123.456.123.456 --master_port=1234 train.py
+$ lightning run model --accelerator=cuda --precision=bf16 --devices=8 --num_nodes=2 --node_rank=0 --main_address=123.456.123.456 --main_port=1234 train_fabric.py
 - Run on the worker node:
-$ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=1 --master_addr=123.456.123.456 --master_port=1234 train.py
+$ lightning run model --accelerator=cuda --precision=bf16 --devices=8 --num_nodes=2 --node_rank=1 --main_address=123.456.123.456 --main_port=1234 train_fabric.py
 (If your cluster does not have Infiniband interconnect prepend NCCL_IB_DISABLE=1)
 """
 

--- a/train_fabric.py
+++ b/train_fabric.py
@@ -164,6 +164,12 @@ if compile:
     unoptimized_model = model
     model = torch.compile(model) # requires PyTorch 2.0
 
+
+# setup according to the precision, accelerator and strategy passed in
+# to the Fabric constructor, that is:
+# 1. move model and optimizer to the chosen device
+# 2. prepare the model for the chosen precision
+# 3. wrap the model according to the chosen strategy
 model, optimizer = fabric.setup(model, optimizer)
 
 

--- a/train_fabric.py
+++ b/train_fabric.py
@@ -72,7 +72,7 @@ config = {k: globals()[k] for k in config_keys} # will be useful for logging
 # -----------------------------------------------------------------------------
 
 # Try also strategy="ddp" or strategy="deepspeed" with devices > 1
-fabric = Fabric(precision="bf16")
+fabric = Fabric()
 
 master_process = fabric.global_rank == 0
 

--- a/train_fabric.py
+++ b/train_fabric.py
@@ -1,0 +1,262 @@
+"""
+This training script can be run both on a single gpu in debug mode,
+and also in a larger training run with distributed data parallel (ddp).
+
+To run on a single GPU, example:
+$ python train.py --batch_size=32 --compile=False
+
+To run with DDP on 4 gpus on 1 node, example:
+$ torchrun --standalone --nproc_per_node=4 train.py
+
+To run with DDP on 4 gpus across 2 nodes, example:
+- Run on the first (master) node with example IP 123.456.123.456:
+$ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=0 --master_addr=123.456.123.456 --master_port=1234 train.py
+- Run on the worker node:
+$ torchrun --nproc_per_node=8 --nnodes=2 --node_rank=1 --master_addr=123.456.123.456 --master_port=1234 train.py
+(If your cluster does not have Infiniband interconnect prepend NCCL_IB_DISABLE=1)
+"""
+
+import os
+import time
+import math
+import pickle
+
+import numpy as np
+import torch
+from lightning.fabric import Fabric
+
+from model import GPTConfig, GPT
+
+
+# -----------------------------------------------------------------------------
+# default config values designed to train a gpt2 (124M) on OpenWebText
+# I/O
+out_dir = 'out'
+eval_interval = 2000
+log_interval = 1
+eval_iters = 200
+eval_only = False # if True, script exits right after the first eval
+always_save_checkpoint = True # if True, always save a checkpoint after each eval
+init_from = 'scratch' # 'scratch' or 'resume' or 'gpt2*'
+# wandb logging
+wandb_log = False # disabled by default
+wandb_project = 'owt'
+wandb_run_name = 'gpt2' # 'run' + str(time.time())
+# data
+dataset = 'openwebtext'
+gradient_accumulation_steps = 1 # used to simulate larger batch sizes
+batch_size = 12 # if gradient_accumulation_steps > 1, this is the micro-batch size
+block_size = 1024
+# model
+n_layer = 12
+n_head = 12
+n_embd = 768
+dropout = 0.0 # for pretraining 0 is good, for finetuning try 0.1+
+# adamw optimizer
+learning_rate = 6e-4 # max learning rate
+max_iters = 600000 # total number of training iterations
+weight_decay = 1e-2
+beta1 = 0.9
+beta2 = 0.95
+# learning rate decay settings
+decay_lr = True # whether to decay the learning rate
+warmup_iters = 2000 # how many steps to warm up for
+lr_decay_iters = 600000 # should be ~= max_iters per Chinchilla
+min_lr = 6e-5 # minimum learning rate, should be ~= learning_rate/10 per Chinchilla
+# system
+compile = True # use PyTorch 2.0 to compile the model to be faster
+# -----------------------------------------------------------------------------
+config_keys = [k for k,v in globals().items() if not k.startswith('_') and isinstance(v, (int, float, bool, str))]
+exec(open('configurator.py').read()) # overrides from command line or config file
+config = {k: globals()[k] for k in config_keys} # will be useful for logging
+# -----------------------------------------------------------------------------
+
+# Try also strategy="ddp" or strategy="deepspeed"
+fabric = Fabric(accelerator="cuda", devices=1, precision="bf16")
+fabric.launch()
+
+master_process = fabric.global_rank == 0
+
+if master_process == 0:
+    os.makedirs(out_dir, exist_ok=True)
+
+fabric.seed_everything(1337 + fabric.global_rank)
+torch.backends.cuda.matmul.allow_tf32 = True # allow tf32 on matmul
+torch.backends.cudnn.allow_tf32 = True # allow tf32 on cudnn
+
+# poor man's data loader, TODO evaluate need for actual DataLoader
+data_dir = os.path.join('data', dataset)
+train_data = np.memmap(os.path.join(data_dir, 'train.bin'), dtype=np.uint16, mode='r')
+val_data = np.memmap(os.path.join(data_dir, 'val.bin'), dtype=np.uint16, mode='r')
+def get_batch(split):
+    data = train_data if split == 'train' else val_data
+    ix = torch.randint(len(data) - block_size, (batch_size,))
+    x = torch.stack([torch.from_numpy((data[i:i+block_size]).astype(np.int64)) for i in ix])
+    y = torch.stack([torch.from_numpy((data[i+1:i+1+block_size]).astype(np.int64)) for i in ix])
+    x, y = fabric.to_device((x, y))
+    return x, y
+
+# init these up here, can override if init_from='resume' (i.e. from a checkpoint)
+iter_num = 0
+best_val_loss = 1e9
+
+# attempt to derive vocab_size from the dataset
+meta_path = os.path.join(data_dir, 'meta.pkl')
+if os.path.exists(meta_path):
+    with open(meta_path, 'rb') as f:
+        meta = pickle.load(f)
+    vocab_size = meta['vocab_size']
+    print(f"vocab_size = {vocab_size} (from {meta_path})")
+else:
+    print(f"vocab_size not found in {meta_path}, using GPT-2 default of 50257")
+    vocab_size = 50257
+
+# model init
+model_args = dict(n_layer = n_layer, n_head = n_head, n_embd = n_embd, block_size = block_size, dropout = dropout, vocab_size = vocab_size)
+if init_from == 'scratch':
+    # init a new model from scratch
+    print("Initializing a new model from scratch")
+    gptconf = GPTConfig(**model_args)
+    model = GPT(gptconf)
+elif init_from == 'resume':
+    print(f"Resuming training from {out_dir}")
+    # resume training from a checkpoint.
+    ckpt_path = os.path.join(out_dir, 'ckpt.pt')
+    checkpoint = torch.load(ckpt_path, map_location=device)
+    checkpoint_model_args = checkpoint['model_args']
+    for k, v in model_args.items():
+        assert checkpoint_model_args[k] == v, "for now"
+        # TODO: think through how passed in params should interact with checkpoint params
+    gptconf = GPTConfig(**model_args)
+    model = GPT(gptconf)
+    state_dict = checkpoint['model']
+    # fix the keys of the state dictionary :(
+    # honestly no idea how checkpoints sometimes get this prefix, have to debug more
+    unwanted_prefix = '_orig_mod.'
+    for k,v in list(state_dict.items()):
+        if k.startswith(unwanted_prefix):
+            state_dict[k[len(unwanted_prefix):]] = state_dict.pop(k)
+    model.load_state_dict(state_dict)
+    iter_num = checkpoint['iter_num']
+    best_val_loss = checkpoint['best_val_loss']
+elif init_from.startswith('gpt2'):
+    print(f"Initializing from OpenAI GPT-2 weights: {init_from}")
+    # initialize from OpenAI GPT-2 weights
+    override_args = dict(dropout=dropout)
+    model = GPT.from_pretrained(init_from, override_args)
+    # read off and override the GPT sizing model args from the model config
+    model_args['n_layer'] = model.config.n_layer
+    model_args['n_head'] = model.config.n_head
+    model_args['n_embd'] = model.config.n_embd
+# crop down the model block size if desired
+if block_size < model.config.block_size:
+    model.crop_block_size(block_size)
+
+
+# optimizer
+optimizer = model.configure_optimizers(weight_decay, learning_rate, (beta1, beta2))
+if init_from == 'resume':
+    optimizer.load_state_dict(checkpoint['optimizer'])
+
+# compile the model
+if compile:
+    print("compiling the model... (takes a ~minute)")
+    unoptimized_model = model
+    model = torch.compile(model) # requires PyTorch 2.0
+
+model, optimizer = fabric.setup(model, optimizer)
+
+
+@torch.no_grad()
+def estimate_loss():
+    out = {}
+    model.eval()
+    for split in ['train', 'val']:
+        losses = torch.zeros(eval_iters)
+        for k in range(eval_iters):
+            X, Y = get_batch(split)
+            logits, loss = model(X, Y)
+            losses[k] = loss.item()
+        out[split] = losses.mean()
+    model.train()
+    return out
+
+# learning rate decay scheduler (cosine with warmup)
+def get_lr(iter):
+    # 1) linear warmup for warmup_iters steps
+    if iter < warmup_iters:
+        return learning_rate * iter / warmup_iters
+    # 2) if iter > lr_decay_iters, return min learning rate
+    if iter > lr_decay_iters:
+        return min_lr
+    # 3) in between, use cosine decay down to min learning rate
+    decay_ratio = (iter - warmup_iters) / (lr_decay_iters - warmup_iters)
+    assert 0 <= decay_ratio <= 1
+    coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio)) # coeff ranges 0..1
+    return min_lr + coeff * (learning_rate - min_lr)
+
+# logging
+if wandb_log and master_process == 0:
+    import wandb
+    wandb.init(project=wandb_project, name=wandb_run_name, config=config)
+
+# training loop
+t0 = time.time()
+while True:
+
+    # determine the learning rate for this iteration
+    if decay_lr:
+        lr = get_lr(iter_num)
+        for param_group in optimizer.param_groups:
+            param_group['lr'] = lr
+    else:
+        lr = learning_rate
+
+    # evaluate the loss on train/val sets and write checkpoints
+    if iter_num % eval_interval == 0 and master_process:
+        losses = estimate_loss()
+        print(f"step {iter_num}: train loss {losses['train']:.4f}, val loss {losses['val']:.4f}")
+        if wandb_log:
+            wandb.log({
+                "iter": iter_num,
+                "train/loss": losses['train'],
+                "val/loss": losses['val'],
+                "lr": lr,
+            })
+        if losses['val'] < best_val_loss or always_save_checkpoint:
+            best_val_loss = losses['val']
+            if iter_num > 0:
+                checkpoint = {
+                    'model': model.state_dict(),
+                    'optimizer': optimizer.state_dict(),
+                    'model_args': model_args,
+                    'iter_num': iter_num,
+                    'best_val_loss': best_val_loss,
+                    'config': config,
+                }
+                print(f"saving checkpoint to {out_dir}")
+                fabric.save(checkpoint, os.path.join(out_dir, 'ckpt.pt'))
+    if iter_num == 0 and eval_only:
+        break
+
+    # forward backward update, with optional gradient accumulation to simulate larger batch size
+    optimizer.zero_grad(set_to_none=True)
+    for micro_step in range(gradient_accumulation_steps):
+        X, Y = get_batch('train')
+        with fabric.no_backward_sync(model, enabled=(micro_step < gradient_accumulation_steps - 1)):
+            logits, loss = model(X, Y)
+            fabric.backward(loss)
+    optimizer.step()
+
+    # timing and logging
+    t1 = time.time()
+    dt = t1 - t0
+    t0 = t1
+    if iter_num % log_interval == 0 and master_process:
+        lossf = loss.item() # loss as float. TODO note CPU-GPU sync! profile, make sure not too slow
+        print(f"iter {iter_num}: loss {lossf:.4f}, time {dt*1000:.2f}ms")
+    iter_num += 1
+
+    # termination conditions
+    if iter_num > max_iters:
+        break

--- a/train_fabric.py
+++ b/train_fabric.py
@@ -71,8 +71,8 @@ exec(open('configurator.py').read()) # overrides from command line or config fil
 config = {k: globals()[k] for k in config_keys} # will be useful for logging
 # -----------------------------------------------------------------------------
 
-# Try also strategy="ddp" or strategy="deepspeed"
-fabric = Fabric(accelerator="cuda", devices=1, precision="bf16")
+# Try also strategy="ddp" or strategy="deepspeed" with devices > 1
+fabric = Fabric(accelerator="cuda", devices=4, strategy="ddp", precision="bf16")
 fabric.launch()
 
 master_process = fabric.global_rank == 0

--- a/train_fabric.py
+++ b/train_fabric.py
@@ -72,7 +72,7 @@ config = {k: globals()[k] for k in config_keys} # will be useful for logging
 # -----------------------------------------------------------------------------
 
 # Try also strategy="ddp" or strategy="deepspeed" with devices > 1
-fabric = Fabric(accelerator="cuda", precision="bf16")
+fabric = Fabric(precision="bf16")
 
 master_process = fabric.global_rank == 0
 


### PR DESCRIPTION
# Why Fabric?

Fabric is a thin layer above PyTorch, forming a toolset that helps you minimize the amount of boilerplate code needed when building your own Trainer! [Learn more about it in our documentation](https://pytorch-lightning.readthedocs.io/en/latest/fabric/fabric.html). 

Closes #1 

# Installation

Fabric is in preview, install the latest release of Lightning 1.9.0:

```
pip install -U lightning
```
And the rest for nano-GPT:
```
pip install numpy datasets tiktoken wandb tqdm networkx
```
Optional:
```
pip install deepspeed
```

# Run

Single GPU:
```
lightning run model --accelerator=cuda --precision=bf16 train_fabric.py
```

4 GPUs, single node:
```
lightning run model --accelerator=cuda --precision=bf16 --devices=4 train_fabric.py
```

8 GPUs, 2 nodes:
```
lightning run model ... --num_nodes=2 --node_rank=0 --main_address=123.456.123.456 --main_port=1234 train_fabric.py
lightning run model ... --num_nodes=2 --node_rank=1 --main_address=123.456.123.456 --main_port=1234 train_fabric.py
```

# Benchmarks

To be re-run. See #1 for previous results.